### PR TITLE
Ability to set default value of if $qTick should be enabled

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -6,14 +6,17 @@ var ngImprovedTestingConfigFlags = {
 };
 
 var ngImprovedTestingConfig = {
-    $qTickEnable: function() {
-        afterEach(function() {
-            ngImprovedTestingConfigFlags.$qTick = false;
+    $setQTickDefault: function (isEnableAtDefault) {
+        beforeEach(function() {
+            console.log('ngImprovedTestingConfig.$qTickDefault', ngImprovedTestingConfig.$qTickDefault);
+            ngImprovedTestingConfigFlags.$qTick = isEnableAtDefault;
         });
-
-        return function() {
-            ngImprovedTestingConfigFlags.$qTick = true;
-        };
+    },
+    $qTickEnable: function() {
+        ngImprovedTestingConfigFlags.$qTick = true;
+    },
+    $qTickDisable: function() {
+        ngImprovedTestingConfigFlags.$qTick = false;
     }
 };
 


### PR DESCRIPTION
With the proposed change one could use the following to enable $qTick for all tests

beforeAll(function() {
    ngImprovedTesting.config.$qTickDefault(true);
})

and disable it on old tests that don't support $qTick with:

ngImprovedTesting.config.$qTickDisable();