### PR TITLE
Update config.js

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -6,14 +6,16 @@ var ngImprovedTestingConfigFlags = {
 };
 
 var ngImprovedTestingConfig = {
-    $qTickEnable: function() {
-        afterEach(function() {
-            ngImprovedTestingConfigFlags.$qTick = false;
+    $setQTickDefault: function (isEnabledByDefault) {
+        beforeEach(function() {
+            ngImprovedTestingConfigFlags.$qTick = isEnabledByDefault;
         });
-
-        return function() {
-            ngImprovedTestingConfigFlags.$qTick = true;
-        };
+    },
+    $qTickEnable: function() {
+        ngImprovedTestingConfigFlags.$qTick = true;
+    },
+    $qTickDisable: function() {
+        ngImprovedTestingConfigFlags.$qTick = false;
     }
 };
 


### PR DESCRIPTION
With the proposed change one could use the following to enable $qTick for all tests

```
beforeAll(function() {
ngImprovedTesting.config.$setQTickDefault(true);
})
```

and disable it on old tests that don't support $qTick with:

`ngImprovedTesting.config.$qTickDisable();`
